### PR TITLE
Update submodule command to remove '--merge' option

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Update submodules
         run: |
-          git submodule update --init --remote --merge
+          git submodule update --init --remote
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
Removed the '--merge' option from the submodule update command.