### PR TITLE
Initial Docs Configuration 

### DIFF
--- a/docs/Hex3/raspberry-pi.md
+++ b/docs/Hex3/raspberry-pi.md
@@ -1,0 +1,1 @@
+# Raspberry Pi Setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Hex Docs
+
+- [Hex1]()
+- [Hex2]()
+- [Hex3](Hex3/index.md)


### PR DESCRIPTION
Initial Docs Configuration to move away from Github Wiki as it is not scalable or maintainable enough