### PR TITLE
Use Pages artifact deployment (remove peaceiris push) to avoid git pu…

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -37,14 +37,9 @@ jobs:
           python -m mkdocs build --clean
           echo "Built site contents:" && ls -la site || true
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          publish_branch: gh-pages
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Prepare site for Pages
+        run: |
+          echo "Built site contents:" && ls -la site || true
 
   configure-pages:
     needs: build


### PR DESCRIPTION
…sh permission errors; keep configure-pages + deploy-pages